### PR TITLE
Home optimisations

### DIFF
--- a/app/models/movement.rb
+++ b/app/models/movement.rb
@@ -15,16 +15,10 @@ class Movement < ApplicationRecord
 
   # for Select2 years
   def self.all_years
-    @years = []
-      self.all.each do |m|
-        unless @years.include?(m.year)
-          @years << m.year
-        end
-      end
-    return @years
+    @all_years ||= distinct("year").order(:year).pluck(:year)
   end
 
   def self.max_year
-    @max_year = self.all_years.max
+    @max_year ||= self.all_years.max
   end
 end

--- a/app/models/type.rb
+++ b/app/models/type.rb
@@ -15,20 +15,16 @@ class Type < ApplicationRecord
   # for Select2 flows
   def self.all_flows
     # working on enum flow (array)
-    @flows = Type.flows.keys
+    Type.flows.keys
   end
 
   # for Select2 families
   def self.all_families
-    @families = []
-      Type.all.order(:code).each do |t|
-        unless @families.include?({code: t.code, label: t.label})
-          if t.code.to_s.length == 1
-            @families << {code: t.code, label: t.label}
-          end
-        end
-      end
-    return @families
+    keys = [:code, :label]
+
+    Type.distinct.where("LENGTH(code) = 1").order(:code).pluck(*keys).map do |type|
+      Hash[keys.zip(type)]
+    end
   end
 
   # for Select2 subfamilies1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/test/fixtures/files/types.csv
+++ b/test/fixtures/files/types.csv
@@ -2,3 +2,4 @@ code,label,unit,description
 A,tonnage brut total,tonnes,Tonnage brut total (A1+A2+A3)
 A1,vrac liquide,tonnes,Toutes marchandises liquides en vrac (A11+A12)
 A11,hydrocarbures,tonnes,Produits pétroliers (A111+A112+A113)
+B,conteneurs (nombres),conteneurs,Nombre de conteneurs de 20' ou plus, avec ou sans cargaison, levés ou roulés (B1+B2)

--- a/test/jobs/import_job_test.rb
+++ b/test/jobs/import_job_test.rb
@@ -11,7 +11,7 @@ class ImportJobTest < ActiveJob::TestCase
     stub_geocoder_fixtures
 
     assert_difference "Harbour.count", +2 do
-      ImportJob.perform_now(@user.id, file_to_named_rows(file))
+      ImportJob.perform_now(@user.id, csv_file_to_named_rows(file))
     end
 
     assert Harbour.exists?(name: "ajaccio", address: "ajaccio", country: "France")
@@ -22,7 +22,7 @@ class ImportJobTest < ActiveJob::TestCase
     file = file_fixture("types.csv")
 
     assert_difference "Type.count", +6 do
-      ImportJob.perform_now(@user.id, file_to_named_rows(file))
+      ImportJob.perform_now(@user.id, csv_file_to_named_rows(file))
     end
 
     assert Type.exists?(code: "a", label: "tonnage brut total", flow: "imp")
@@ -33,11 +33,11 @@ class ImportJobTest < ActiveJob::TestCase
     file = file_fixture("movements.csv")
 
     stub_geocoder_fixtures
-    ImportJob.perform_now(@user.id, file_to_named_rows(file_fixture("harbours.csv")))
-    ImportJob.perform_now(@user.id, file_to_named_rows(file_fixture("types.csv")))
+    ImportJob.perform_now(@user.id, csv_file_to_named_rows(file_fixture("harbours.csv")))
+    ImportJob.perform_now(@user.id, csv_file_to_named_rows(file_fixture("types.csv")))
 
     assert_difference "Movement.count", +6 do
-      ImportJob.perform_now(@user.id, file_to_named_rows(file))
+      ImportJob.perform_now(@user.id, csv_file_to_named_rows(file))
     end
 
     ajaccio = Harbour.find_by!(name: "ajaccio")
@@ -61,9 +61,5 @@ class ImportJobTest < ActiveJob::TestCase
     assert_match "Échec", email.subject
     # current file name will be in the exception backtrace
     assert_match __FILE__, email.html_part.body.to_s
-  end
-
-  def file_to_named_rows(file)
-    CSV.read(file, headers: true).map(&:to_h)
   end
 end

--- a/test/jobs/import_job_test.rb
+++ b/test/jobs/import_job_test.rb
@@ -21,7 +21,7 @@ class ImportJobTest < ActiveJob::TestCase
   test "import create types in db" do
     file = file_fixture("types.csv")
 
-    assert_difference "Type.count", +6 do
+    assert_difference "Type.count", +8 do
       ImportJob.perform_now(@user.id, csv_file_to_named_rows(file))
     end
 

--- a/test/models/movement_test.rb
+++ b/test/models/movement_test.rb
@@ -1,7 +1,11 @@
 require 'test_helper'
 
 class MovementTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    load_fixtures_files
+  end
+
+  test ".all_years returns distinct years" do
+    assert_equal [2014, 2015, 2016], Movement::all_years
+  end
 end

--- a/test/models/type_test.rb
+++ b/test/models/type_test.rb
@@ -1,7 +1,16 @@
 require 'test_helper'
 
 class TypeTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    load_fixtures_files
+  end
+
+  test ".all_families returns only families with code & labels" do
+    expected = [
+      { code: "a", label: "tonnage brut total" },
+      { code: "b", label: "conteneurs (nombres)" },
+    ]
+
+    assert_equal expected, Type::all_families
+  end
 end

--- a/test/services/importer_test.rb
+++ b/test/services/importer_test.rb
@@ -19,7 +19,7 @@ class ImporterTest < ActiveSupport::TestCase
   end
 
   test "enqueue ImportJob with the expected arguments" do
-    assert_enqueued_with(job: ImportJob, queue: 'import', args: [@user.id, file_to_named_rows]) do
+    assert_enqueued_with(job: ImportJob, queue: 'import', args: [@user.id, csv_file_to_named_rows(@file)]) do
       Importer.enqueue_jobs(@user, @file)
     end
   end
@@ -28,11 +28,5 @@ class ImporterTest < ActiveSupport::TestCase
     assert_enqueued_with(job: FinnishImportJob, queue: 'import', args: [@user.id]) do
       Importer.enqueue_jobs(@user, @file)
     end
-  end
-
-  private
-
-  def file_to_named_rows
-    CSV.read(@file, headers: true).map(&:to_h)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,3 +22,22 @@ def stub_geocoder_fixtures
   stub_request(:get, "https://maps.googleapis.com/maps/api/geocode/json?address=port%20bastia,%20bastia,%20France&key=&language=en&sensor=false").
     to_return(status: 200, body: file_fixture("bastia.json"))
 end
+
+def load_fixtures_files
+  user_id = users(:admin).id
+
+  stub_geocoder_fixtures
+
+  %w[
+    harbours
+    types
+    movements
+  ].each do |name|
+    file = file_fixture("#{name}.csv")
+    ImportJob.perform_now(user_id, csv_file_to_named_rows(file))
+  end
+end
+
+def csv_file_to_named_rows(file)
+  CSV.read(file, headers: true).map(&:to_h)
+end


### PR DESCRIPTION
A merger *après* l'autre PR.

Optimise 2 méthodes qui chargeaient tous les objets en base et bouclaient dessus en les remplaçant chacune par une requête ciblée beaucoup plus light ( + tests).

Il faudrait refactoriser un peu dans la même idée toute la logique de sélection des harbours (même si ce sera forcément plus compliqué) : bcp trop requêtes sont faites pour générer les geojson et c'est à mon avis ce qui cause encore quelques lenteurs au chargement de la page (Cf log de toutes les requêtes quand on charge la requête : `tail -f log/development.log`
Par ailleurs pour chaque harbour qui répond aux critères, la méthode `totvol_filter` très coûteuse (load les movements et les types) est appelée 2 fois (ligne 13 + ligne 23).
A mon avis plutôt que "corriger" l'existant, ça pourrait être plus fructueux de repartir de la feuille blanche pour ça. Avec de l'expérience supplémentaire que t'as accumulée depuis tu devrais arriver à faire un peu plus efficace.

Et en TDD pour t'aider et être sûr que le résultat est le bon: écrit d'abord les tests et l'implémentation viendra.
Au final tu veux générer un geojson, pour une liste d'harbours qui correspondent aux filtres.
Je vois 2 méthodes "publiques" : 
- une qui filtre (en une seule requête c'st ptet possible, ou alors avec des sous-requêtes qui ne prennent que les ids
- une qui génère le geojson d'un harbour donné (idéalement celle-ci doit pouvoir se faire sans requête supplémentaire à la base).

Ah et dernière chose: n'envoie pas les params directement à tes modèles. C'est au controller de filtrer et récupérer les bons params, et donner les valeurs qu'il faut à chaque méthode.
 
Enfin, c'est pas de l'optimisation mais maintenant le SSL est forcé en prod.