### PR TITLE
fix bug total not working yet

### DIFF
--- a/lib/harbours_filters.rb
+++ b/lib/harbours_filters.rb
@@ -50,11 +50,20 @@ class HarboursFilters
     # imp or an exp volume
     return movements.select(&:"#{flow}?").sum(&:volume) if %w[imp exp].include?(flow)
 
-    # we want the total. Either we have a movemnet for that, either this is the sum of movements
-    movement_tot = movements.detect(&:tot?)
-    return movement_tot.volume if movement_tot.present?
+    if movements.detect(&:tot?).present?
+      vol_movement_with_tot = movements.select(&:"#{flow}?").sum(&:volume) if %w[tot].include?(flow)
+      vol_movement_without_tot = movements.select(&:"#{flow}?").sum(&:volume) if %w[imp exp].include?(flow)
+      vol_all_movements = vol_movement_with_tot.to_i + vol_movement_without_tot.to_i
+    else
+      movements.sum(&:volume)
+    end
 
-    movements.sum(&:volume)
+    # we want the total. Either we have a movemnet for that, either this is the sum of movements
+    # movement_tot = movements.detect(&:tot?)
+    # return movement_tot.volume if movement_tot.present?
+
+    # movements.sum(&:volume)
+
   end
 
   def compute_unit(movements)


### PR DESCRIPTION
Le problème est donc sur le traitement des flow. Voici mon "meilleur essai" de l'aprem... pas suffisant. 
En fait il faut à la fois garder les vol des tot pour les codes qui ont des lignes tot + ajouter les imp + exp pour les codes qui n'ont pas de ligne tot. Alors que là on ne fait que garder les lignes tot + ça empêche d'additionner les autres sous-filtres qui n'ont pas de ligne tot.
L'exemple qui ne marche pas: ajouter dans la DB des lignes Tot pour D3 ==> filtre D1 + D2 + D3 n'affiche que D3, et pour les D3 qui n'ont pas de ligne tot on n'ajoute pas imp + exp. Je t'envoie l'exemple de CSV par slack.
J'ai essayé de modifier harbours_filters avec ce que j'en comprenais. Je pense qu'il faut peut être regarder aussi du côté de harbours_params_extractor et notamment le .first ligne 35, qui m'a l'air de ne prendre qu'une petite partie au lieu d'un array des différentes options. Mais je ne comprends pas tout le fonctionnement de ton optimisation sorry...
N'hésite pas à ne pas repartir de cette PR!