### PR TITLE
Fix movements filtered computation with mixed imp/exp/tot types

### DIFF
--- a/app/models/movement.rb
+++ b/app/models/movement.rb
@@ -13,7 +13,7 @@ class Movement < ApplicationRecord
   #   "#{self.type.code} #{self.type.flow}"
   # end
 
-  delegate :tot?, :imp?, :exp?, to: :type
+  delegate :code, :tot?, :imp?, :exp?, to: :type
 
   # for Select2 years
   def self.all_years

--- a/test/factories/harbours.rb
+++ b/test/factories/harbours.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :harbour do
-    country "France"
-    name "Le Rove"
+    country { "France" }
+    name { "Le Rove" }
     address { name }
-    latitude 43.339
-    longitude 5.257
+    latitude { 43.339 }
+    longitude { 5.257 }
   end
 end

--- a/test/factories/movements.rb
+++ b/test/factories/movements.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :movement do
     harbour
     type
-    year 2016
-    terminal ""
-    pol_pod ""
-    volume 1_000
+    year { 2016 }
+    terminal { "" }
+    pol_pod { "" }
+    volume { 1_000 }
   end
 end

--- a/test/factories/types.rb
+++ b/test/factories/types.rb
@@ -1,17 +1,17 @@
 FactoryBot.define do
   factory :type do
-    code "b1"
-    label "Some label"
-    description ""
-    flow "tot"
-    unit "tonnes"
+    code { "b1" }
+    label { "Some label" }
+    description { "" }
+    flow { "tot" }
+    unit { "tonnes" }
 
     trait :imp do
-      flow "imp"
+      flow { "imp" }
     end
 
     trait :exp do
-      flow "exp"
+      flow { "exp" }
     end
   end
 end

--- a/test/lib/harbours_filters_test.rb
+++ b/test/lib/harbours_filters_test.rb
@@ -76,6 +76,21 @@ class HarboursFiltersTest < ActiveSupport::TestCase
     assert_equal 12_500, harbours.first.filtered_volume
   end
 
+  test "filtered volume with multiple subfilters, mixing tot & imp+exp flows" do
+    ajaccio = Harbour.find_by!(name: "ajaccio")
+
+    create(:movement, harbour: ajaccio, volume: 10_000, type: create(:type, code: "b1"))
+    create(:movement, harbour: ajaccio, volume: 1_500, type: create(:type, :imp, code: "b1"))
+    create(:movement, harbour: ajaccio, volume: 1_500, type: create(:type, :exp, code: "b1"))
+    create(:movement, harbour: ajaccio, volume: 100, type: create(:type, :imp, code: "b2"))
+    create(:movement, harbour: ajaccio, volume: 200, type: create(:type, :exp, code: "b2"))
+
+
+    harbours = filters_for({ flow: "tot", year: "2016", fam: "b", sub_one: %w[b1 b2] }).harbours
+    # sum must be b1 tot + b2 imp + b2 exp
+    assert_equal 10_300, harbours.first.filtered_volume
+  end
+
   test "set family unit without filtering sub families" do
     harbours = filters_for({}).harbours
 


### PR DESCRIPTION
En principe c'est réglé, cf exemple dans le test que j'ai rajouté (le flow par défaut d'un type étant "tot").

On groupe d'abord les movements par code, et code par code on utilise soit le movement total, soit imp+exp. Puis on somme le tout.

Je te laisse vérifier sur staging avec les vraies données et mettre en prod si c'est OK :)

